### PR TITLE
Feat: UserDefault Wrapper 구현 및 필요한 값 추가

### DIFF
--- a/WhisperBox/Utils/UserDefaults/LocalData.swift
+++ b/WhisperBox/Utils/UserDefaults/LocalData.swift
@@ -1,0 +1,14 @@
+//
+//  LocalData.swift
+//  WhisperBox
+//
+//  Created by 한건희 on 3/26/25.
+//
+
+struct LocalData {
+    @UserDefault(key: "userNickname", defaultValue: "")
+    static var userNickname: String
+    
+    @UserDefault(key: "loginNickname", defaultValue: "")
+    static var loginNickname: String
+}

--- a/WhisperBox/Utils/UserDefaults/UserDefaultWrapper.swift
+++ b/WhisperBox/Utils/UserDefaults/UserDefaultWrapper.swift
@@ -1,0 +1,34 @@
+//
+//  UserDefaultWrapper.swift
+//  WhisperBox
+//
+//  Created by 한건희 on 3/26/25.
+//
+
+import Foundation
+
+@propertyWrapper
+struct UserDefault<T> {
+    private let key: String
+    private let defaultValue: T
+    private let userDefaults: UserDefaults
+    
+    init(key: String, defaultValue: T, userDefaults: UserDefaults = .standard) {
+        self.key = key
+        self.defaultValue = defaultValue
+        self.userDefaults = userDefaults
+    }
+    
+    var wrappedValue: T {
+        get {
+            return userDefaults.object(forKey: key) as? T ?? defaultValue
+        }
+        set {
+            userDefaults.set(newValue, forKey: key)
+        }
+    }
+    
+    func remove() {
+        userDefaults.removeObject(forKey: key)
+    }
+}


### PR DESCRIPTION
## LocalData.swift 파일에 현재 필요한 두 개의 값을 먼저 추가해놓았습니다.

사용 시에는 LocalData.userNickname 처럼 사용하시면 됩니다.

추가적인 로컬 값을 저장할 필요가 있을 시에는
@UserDefault(key: {키 값}, defaultValue: {데이터 변수 타입 기본값}) static var {변수명}: {데이터 변수 타입}
으로 추가해주시면 됩니다.