### PR TITLE
✨ 전체 유저 목록 조회 기능 추가

### DIFF
--- a/WhisperBox/Database/FirebaseService.swift
+++ b/WhisperBox/Database/FirebaseService.swift
@@ -91,6 +91,28 @@ class FirebaseService {
         }
         return .success(letterList)
     }
+    
+    // MARK: 전체 유저 목록 가져오기
+    func getAllUsers() async -> Result<[GetUserResModel], WhisperBoxError> {
+        do {
+            let dataSnapshot = try await database.child("users").getData()
+            
+            var userList: [GetUserResModel] = []
+
+            for child in dataSnapshot.children {
+                if let childSnapshot = child as? DataSnapshot,
+                   let childValue = childSnapshot.value as? [String: Any],
+                   let nickName = childValue["nickName"] as? String,
+                   let password = childValue["password"] as? String {
+                    userList.append(GetUserResModel(nickName: nickName, password: password))
+                }
+            }
+            
+            return .success(userList)
+        } catch {
+            return .failure(.firebaseError)
+        }
+    }
 }
 
 struct GetUserResModel {

--- a/WhisperBoxTests/Firebase/FirebaseTests.swift
+++ b/WhisperBoxTests/Firebase/FirebaseTests.swift
@@ -70,6 +70,18 @@ struct FirebaseTests {
             print(failure)
         }
     }
-    
-    
+
+    // 전체 유저 목록을 가져오는 테스트
+    @Test func getAllUsersTest() async {
+        let result = await FirebaseService.shared.getAllUsers()
+        switch result {
+        case .success(let users):
+            print("\n---- 전체 유저 목록 ----")
+            for user in users {
+                print("닉네임: \(user.nickName), 비밀번호: \(user.password)")
+            }
+        case .failure(let error):
+            print("유저 목록 가져오기 실패: \(error.description)")
+        }
+    }
 }


### PR DESCRIPTION
Why:
- 향후 사용자 선택, 검색 기능을 위해 전체 유저 정보를 불러오는 기능이 필요함

What:
- FirebaseService에 getAllUsers 메서드 추가
  - Realtime Database에서 users 경로를 순회하며 닉네임, 비밀번호 추출
  - 결과를 GetUserResModel 배열로 반환
- FirebaseTests에 getAllUsersTest 테스트 추가

Tags: #firebase #user #database #test